### PR TITLE
Add missing `dune` in examples and minor changes to make them can build

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,15 @@ not work on macos).
 ### Demos
 
 * [MNIST tutorial](./examples/mnist/README.md).
-* [Finetuning a ResNet-18 model](./examples/pretrained/README.md).
+* [Finetuning a ResNet-18 model](./examples/pretrained/README.md) (*).
 * [Generative Adversarial Networks](./examples/gan/README.md).
 * [Running some Python model](./examples/jit/README.md).
-* [ResNet examples on CIFAR-10](./examples/cifar/README.md).
+* [ResNet examples on CIFAR-10](./examples/cifar/README.md) (*).
 * [Character-level RNN](./examples/char_rnn/README.md)
 * [Neural Style Transfer](./examples/neural_transfer/README.md)
+* [Reinforcement Learning](./examples/reinforcement-learning/README.md)
+
+Examples with (*) may encounter runtime exception related to `Torch.argmax`.
 
 Some more advanced applications from external repos:
 
@@ -105,6 +108,10 @@ Some more advanced applications from external repos:
 
 Various pre-trained computer vision models are implemented in the vision library.
 The weight files can be downloaded at the following links:
+
+Updated models
+* ResNet-18 [weights](https://github.com/LaurentMazare/tch-rs/releases/download/mw/resnet18.ot).
+* VGG-16 [weights](https://github.com/LaurentMazare/tch-rs/releases/download/mw/vgg16.ot).
 
 
 * ResNet-18 [weights](https://github.com/LaurentMazare/ocaml-torch/releases/download/v0.1-unstable/resnet18.ot).

--- a/bin/dune
+++ b/bin/dune
@@ -1,6 +1,6 @@
-(executables
- (modes byte exe)
- (names tensor_tools)
- (libraries base cmdliner npy torch_core stdio torch torch_vision)
- (preprocess
-  (pps ppx_jane)))
+; (executables
+;  (modes byte exe)
+;  (names tensor_tools)
+;  (libraries base cmdliner npy torch_core stdio torch torch_vision)
+;  (preprocess
+;   (pps ppx_jane)))

--- a/examples/basics/dune
+++ b/examples/basics/dune
@@ -1,0 +1,3 @@
+(executables
+ (names basics)
+ (libraries torch))

--- a/examples/char_rnn/dune
+++ b/examples/char_rnn/dune
@@ -1,0 +1,3 @@
+(executables
+ (names char_rnn)
+ (libraries torch))

--- a/examples/cifar/dune
+++ b/examples/cifar/dune
@@ -1,0 +1,3 @@
+(executables
+ (names cifar_train)
+ (libraries torch))

--- a/examples/gan/dune
+++ b/examples/gan/dune
@@ -1,0 +1,3 @@
+(executables
+ (names mnist_gan gan_stability)
+ (libraries torch))

--- a/examples/gan/dune
+++ b/examples/gan/dune
@@ -1,3 +1,3 @@
 (executables
  (names mnist_gan gan_stability)
- (libraries torch))
+ (libraries torch torch_vision))

--- a/examples/jit/dune
+++ b/examples/jit/dune
@@ -1,0 +1,3 @@
+(executables
+ (names load_and_run)
+ (libraries torch torch_vision))

--- a/examples/min-gpt/dune
+++ b/examples/min-gpt/dune
@@ -1,0 +1,3 @@
+(executables
+ (names mingpt)
+ (libraries torch))

--- a/examples/min-gpt/mingpt.ml
+++ b/examples/min-gpt/mingpt.ml
@@ -74,7 +74,7 @@ let block vs cfg =
     let ys =
       Layer.forward ln2 xs
       |> Layer.forward lin1
-      |> Tensor.gelu
+      |> Tensor.gelu ~approximate:"none"
       |> Layer.forward lin2
       |> Tensor.dropout ~p:resid_pdrop ~is_training
     in
@@ -115,21 +115,21 @@ let sample cfg ~gpt ~dataset ~device =
   let input = Tensor.zeros [ 1; block_size ] ~kind:(T Int64) ~device in
   List.init sampling_length ~f:Fn.id
   |> List.fold_map ~init:input ~f:(fun input _idx ->
-       Stdlib.Gc.full_major ();
-       let logits =
-         Layer.forward_ gpt input ~is_training:false |> Tensor.select ~dim:1 ~index:(-1)
-       in
-       let logits = Tensor.(logits / f temperature) in
-       let sampled_y =
-         Tensor.softmax logits ~dim:(-1) ~dtype:(T Float)
-         |> Tensor.multinomial ~num_samples:1 ~replacement:true
-       in
-       let sampled_char = Text_helper.char dataset ~label:(Tensor.int_value sampled_y) in
-       let input =
-         Tensor.cat [ input; Tensor.view sampled_y ~size:[ 1; 1 ] ] ~dim:1
-         |> Tensor.narrow ~dim:1 ~start:1 ~length:block_size
-       in
-       input, sampled_char)
+    Stdlib.Gc.full_major ();
+    let logits =
+      Layer.forward_ gpt input ~is_training:false |> Tensor.select ~dim:1 ~index:(-1)
+    in
+    let logits = Tensor.(logits / f temperature) in
+    let sampled_y =
+      Tensor.softmax logits ~dim:(-1) ~dtype:(T Float)
+      |> Tensor.multinomial ~num_samples:1 ~replacement:true
+    in
+    let sampled_char = Text_helper.char dataset ~label:(Tensor.int_value sampled_y) in
+    let input =
+      Tensor.cat [ input; Tensor.view sampled_y ~size:[ 1; 1 ] ] ~dim:1
+      |> Tensor.narrow ~dim:1 ~start:1 ~length:block_size
+    in
+    input, sampled_char)
   |> snd
   |> String.of_char_list
 ;;
@@ -146,31 +146,31 @@ let train vs ~cfg ~gpt ~dataset =
     ~checkpoint_base:"min-gpt.ot"
     ~checkpoint_every:(`iters 1)
     (fun ~index:epoch_idx ->
-    Stdio.Out_channel.write_all
-      (Printf.sprintf "out.txt.%d" epoch_idx)
-      ~data:(sample cfg ~gpt ~dataset ~device);
-    let start_time = Unix.gettimeofday () in
-    let sum_loss = ref 0. in
-    Text_helper.iter dataset ~device ~batch_size ~seq_len ~f:(fun batch_idx ~xs ~ys ->
-      let logits = Layer.forward_ gpt xs ~is_training:true in
-      (* Compute the cross-entropy loss. *)
-      let loss =
-        Tensor.cross_entropy_for_logits
-          (Tensor.view logits ~size:[ batch_size * seq_len; labels ])
-          ~targets:(Tensor.view ys ~size:[ batch_size * seq_len ])
-      in
-      sum_loss := !sum_loss +. Tensor.float_value loss;
-      Stdio.printf
-        "%d/%d %f\r%!"
-        batch_idx
-        batches_per_epoch
-        (!sum_loss /. Float.of_int (1 + batch_idx));
-      Optimizer.backward_step ~clip_grad:(Norm2 4.) adam ~loss);
-    Stdio.printf
-      "%d %.0fs %f\n%!"
-      epoch_idx
-      (Unix.gettimeofday () -. start_time)
-      (!sum_loss /. Float.of_int batches_per_epoch))
+       Stdio.Out_channel.write_all
+         (Printf.sprintf "out.txt.%d" epoch_idx)
+         ~data:(sample cfg ~gpt ~dataset ~device);
+       let start_time = Unix.gettimeofday () in
+       let sum_loss = ref 0. in
+       Text_helper.iter dataset ~device ~batch_size ~seq_len ~f:(fun batch_idx ~xs ~ys ->
+         let logits = Layer.forward_ gpt xs ~is_training:true in
+         (* Compute the cross-entropy loss. *)
+         let loss =
+           Tensor.cross_entropy_for_logits
+             (Tensor.view logits ~size:[ batch_size * seq_len; labels ])
+             ~targets:(Tensor.view ys ~size:[ batch_size * seq_len ])
+         in
+         sum_loss := !sum_loss +. Tensor.float_value loss;
+         Stdio.printf
+           "%d/%d %f\r%!"
+           batch_idx
+           batches_per_epoch
+           (!sum_loss /. Float.of_int (1 + batch_idx));
+         Optimizer.backward_step ~clip_grad:(Norm2 4.) adam ~loss);
+       Stdio.printf
+         "%d %.0fs %f\n%!"
+         epoch_idx
+         (Unix.gettimeofday () -. start_time)
+         (!sum_loss /. Float.of_int batches_per_epoch))
 ;;
 
 let () =

--- a/examples/mnist/dune
+++ b/examples/mnist/dune
@@ -1,0 +1,3 @@
+(executables
+ (names conv linear nn)
+ (libraries torch))

--- a/examples/mnist/linear.ml
+++ b/examples/mnist/linear.ml
@@ -35,7 +35,7 @@ let () =
     Tensor.zero_grad bs;
     (* Compute the validation error. *)
     let test_accuracy =
-      Tensor.(argmax (model test_images) = test_labels)
+      Tensor.(argmax ~dim:1 (model test_images) = test_labels)
       |> Tensor.to_kind ~kind:(T Float)
       |> Tensor.sum
       |> Tensor.float_value

--- a/examples/neural_transfer/dune
+++ b/examples/neural_transfer/dune
@@ -1,0 +1,3 @@
+(executables
+ (names neural_transfer)
+ (libraries torch torch_vision))

--- a/examples/neural_transfer/neural_transfer.ml
+++ b/examples/neural_transfer/neural_transfer.ml
@@ -78,7 +78,10 @@ let () =
       (Tensor.float_value content_loss);
     Stdlib.Gc.full_major ();
     if step_idx % 10 = 0
-    then Imagenet.write_image input_var ~filename:(Printf.sprintf "out%d.png" step_idx)
+    then
+      Imagenet.write_image
+        (Tensor.to_device ~device:Device.Cpu input_var)
+        ~filename:(Printf.sprintf "out%d.png" step_idx)
   done;
   Imagenet.write_image input_var ~filename:"out.png"
 ;;

--- a/examples/pretrained/dune
+++ b/examples/pretrained/dune
@@ -1,0 +1,3 @@
+(executables
+ (names finetuning)
+ (libraries torch torch_vision))

--- a/examples/reinforcement-learning/README.md
+++ b/examples/reinforcement-learning/README.md
@@ -1,5 +1,12 @@
 # Reinforcement Learning Examples
 
+To prepare python environment:
+
+```
+pip install gym
+pip install "gymnasium[atari, accept-rom-license]"
+```
+
 These examples illustrate how to implement a couple reinforcement learning
 algorithms to play Atari games.
 More details on the DQN examples can be found on this

--- a/examples/reinforcement-learning/dqn_atari.ml
+++ b/examples/reinforcement-learning/dqn_atari.ml
@@ -208,8 +208,8 @@ let preprocess () =
     let img =
       (* RGB to grey conversion. *)
       Tensor.(d 0 ~factor:0.299 + d 1 ~factor:0.587 + d 2 ~factor:0.114)
-      |> Tensor.slice ~dim:0 ~start:0 ~end_:210 ~step:2
-      |> Tensor.slice ~dim:1 ~start:0 ~end_:160 ~step:2
+      |> Tensor.slice ~dim:0 ~start:(Some 0) ~end_:(Some 210) ~step:2
+      |> Tensor.slice ~dim:1 ~start:(Some 0) ~end_:(Some 160) ~step:2
       |> Tensor.to_type ~type_:(T Uint8)
       |> Tensor.flip ~dims:[ 0; 1 ]
     in
@@ -254,9 +254,10 @@ module E = struct
     let actions = Env_gym_pyml.actions env in
     Stdio.printf "actions: %s\n%!" (String.concat ~sep:"," actions);
     let fire_action =
-      List.find_mapi actions ~f:(fun i -> function
-        | "FIRE" -> Some i
-        | _ -> None)
+      List.find_mapi actions ~f:(fun i ->
+          function
+          | "FIRE" -> Some i
+          | _ -> None)
     in
     { fire_action
     ; nactions = List.length actions

--- a/examples/reinforcement-learning/dqn_pong.ml
+++ b/examples/reinforcement-learning/dqn_pong.ml
@@ -176,8 +176,8 @@ let preprocess () =
       (* RGB to grey conversion. *)
       Tensor.(d 0 ~factor:0.299 + d 1 ~factor:0.587 + d 2 ~factor:0.114)
       |> Tensor.narrow ~dim:0 ~start:35 ~length:160
-      |> Tensor.slice ~dim:0 ~start:0 ~end_:160 ~step:2
-      |> Tensor.slice ~dim:1 ~start:0 ~end_:160 ~step:2
+      |> Tensor.slice ~dim:0 ~start:(Some 0) ~end_:(Some 160) ~step:2
+      |> Tensor.slice ~dim:1 ~start:(Some 0) ~end_:(Some 160) ~step:2
       |> Tensor.unsqueeze ~dim:0
     in
     let diff =

--- a/examples/reinforcement-learning/dune
+++ b/examples/reinforcement-learning/dune
@@ -1,0 +1,3 @@
+(executables
+ (names dqn_atari dqn_pong)
+ (libraries torch torch_vision pyml))

--- a/examples/translation/dune
+++ b/examples/translation/dune
@@ -1,0 +1,3 @@
+(executables
+ (names seq2seq)
+ (libraries torch))

--- a/examples/vae/dune
+++ b/examples/vae/dune
@@ -1,0 +1,3 @@
+(executables
+ (names vae)
+ (libraries torch torch_vision))

--- a/examples/yolo/darknet.ml
+++ b/examples/yolo/darknet.ml
@@ -22,33 +22,33 @@ let parse_config filename =
   let blocks =
     Stdio.In_channel.read_lines filename
     |> List.filter_map ~f:(fun line ->
-         let line = String.strip line in
-         if String.is_empty line || Char.( = ) line.[0] '#' then None else Some line)
+      let line = String.strip line in
+      if String.is_empty line || Char.( = ) line.[0] '#' then None else Some line)
     |> List.group ~break:(fun _ line -> Char.( = ) line.[0] '[')
     |> List.map ~f:(function
-         | block_type :: paramaters ->
-           let block_type =
-             match String.chop_prefix block_type ~prefix:"[" with
-             | None -> failwithf "block-type does not start with [: %s" block_type ()
-             | Some block_type ->
-               (match String.chop_suffix block_type ~suffix:"]" with
-                | None -> failwithf "block-type does not end with ]: %s" block_type ()
-                | Some block_type -> block_type)
-           in
-           let parameters =
-             List.map paramaters ~f:(fun line ->
-               match String.split line ~on:'=' with
-               | [ lhs; rhs ] -> String.strip lhs, String.strip rhs
-               | _ ->
-                 failwithf "parameter line does not contain exactly one equal: %s" line ())
-           in
-           let parameters =
-             match Map.of_alist (module String) parameters with
-             | `Duplicate_key key -> failwithf "multiple %s key for %s" key block_type ()
-             | `Ok parameters -> parameters
-           in
-           { block_type; parameters }
-         | _ -> assert false)
+      | block_type :: paramaters ->
+        let block_type =
+          match String.chop_prefix block_type ~prefix:"[" with
+          | None -> failwithf "block-type does not start with [: %s" block_type ()
+          | Some block_type ->
+            (match String.chop_suffix block_type ~suffix:"]" with
+             | None -> failwithf "block-type does not end with ]: %s" block_type ()
+             | Some block_type -> block_type)
+        in
+        let parameters =
+          List.map paramaters ~f:(fun line ->
+            match String.split line ~on:'=' with
+            | [ lhs; rhs ] -> String.strip lhs, String.strip rhs
+            | _ ->
+              failwithf "parameter line does not contain exactly one equal: %s" line ())
+        in
+        let parameters =
+          match Map.of_alist (module String) parameters with
+          | `Duplicate_key key -> failwithf "multiple %s key for %s" key block_type ()
+          | `Ok parameters -> parameters
+        in
+        { block_type; parameters }
+      | _ -> assert false)
   in
   match blocks with
   | { block_type = "net"; parameters } :: blocks -> { blocks; parameters }
@@ -135,8 +135,8 @@ let yolo ~index ~prev_channels ~parameters =
     find_key ~index ~parameters "anchors" ~f:int_list_of_string
     |> List.groupi ~break:(fun i _ _ -> i % 2 = 0)
     |> List.map ~f:(function
-         | [ p; q ] -> p, q
-         | _ -> failwithf "odd number of elements in mask at index %d" index ())
+      | [ p; q ] -> p, q
+      | _ -> failwithf "odd number of elements in mask at index %d" index ())
     |> Array.of_list
   in
   let anchors =
@@ -192,11 +192,9 @@ let detect xs ~image_height ~anchors ~classes ~device =
     |> Tensor.unsqueeze ~dim:0
   in
   slice_apply_and_set xs ~start:2 ~length:2 ~f:Tensor.(fun xs -> exp xs * anchors);
-  slice_apply_and_set
-    xs
-    ~start:0
-    ~length:4
-    ~f:Tensor.(fun xs -> xs * f (Float.of_int stride));
+  slice_apply_and_set xs ~start:0 ~length:4 ~f:(fun xs ->
+    let stride_float = Float.of_int stride in
+    Tensor.(xs * f stride_float));
   xs
 ;;
 
@@ -229,38 +227,38 @@ let build_model vs t =
       blocks
       ~init:(xs, None)
       ~f:(fun index (xs, detections) (_channels, block) ->
-      let ys, detections =
-        match block with
-        | `layers layers ->
-          let ys =
-            List.fold layers ~init:xs ~f:(fun xs l -> Layer.forward_ l xs ~is_training)
-          in
-          ys, detections
-        | `route layers ->
-          let ys =
-            List.map layers ~f:(fun i -> Hashtbl.find_exn outputs (index - i))
-            |> Tensor.cat ~dim:1
-          in
-          ys, detections
-        | `shortcut from ->
-          let ys =
-            Tensor.( + )
-              (Hashtbl.find_exn outputs (index - 1))
-              (Hashtbl.find_exn outputs (index - from))
-          in
-          ys, detections
-        | `yolo (classes, anchors) ->
-          let ys =
-            detect xs ~image_height ~anchors ~classes ~device:(Var_store.device vs)
-          in
-          let detections =
-            match detections with
-            | None -> ys
-            | Some detections -> Tensor.cat [ detections; ys ] ~dim:1
-          in
-          ys, Some detections
-      in
-      Hashtbl.add_exn outputs ~key:index ~data:ys;
-      ys, detections)
+        let ys, detections =
+          match block with
+          | `layers layers ->
+            let ys =
+              List.fold layers ~init:xs ~f:(fun xs l -> Layer.forward_ l xs ~is_training)
+            in
+            ys, detections
+          | `route layers ->
+            let ys =
+              List.map layers ~f:(fun i -> Hashtbl.find_exn outputs (index - i))
+              |> Tensor.cat ~dim:1
+            in
+            ys, detections
+          | `shortcut from ->
+            let ys =
+              Tensor.( + )
+                (Hashtbl.find_exn outputs (index - 1))
+                (Hashtbl.find_exn outputs (index - from))
+            in
+            ys, detections
+          | `yolo (classes, anchors) ->
+            let ys =
+              detect xs ~image_height ~anchors ~classes ~device:(Var_store.device vs)
+            in
+            let detections =
+              match detections with
+              | None -> ys
+              | Some detections -> Tensor.cat [ detections; ys ] ~dim:1
+            in
+            ys, Some detections
+        in
+        Hashtbl.add_exn outputs ~key:index ~data:ys;
+        ys, detections)
     |> fun (_last, detections) -> Option.value_exn detections)
 ;;

--- a/examples/yolo/dune
+++ b/examples/yolo/dune
@@ -1,0 +1,3 @@
+(executables
+ (names yolo)
+ (libraries torch torch_vision))

--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -24,6 +24,7 @@ let or_else o ~f =
 
 let torch_flags () =
   let dynamic_links = [ "c10"; "torch_cpu"; "torch" ] in
+  let dynamic_link_flags = List.map ~f:(fun lib -> [%string "-l%{lib}"]) dynamic_links in
   let config ~include_dir ~lib_dir =
     let cflags =
       [ "-isystem"
@@ -34,9 +35,7 @@ let torch_flags () =
     in
     let libs =
       [ Printf.sprintf "-Wl,-rpath,%s" lib_dir; Printf.sprintf "-L%s" lib_dir ]
-      @ List.map
-          ~f:(fun lib -> [%string "-l%{lib_dir}"] /^ [%string "lib%{lib}.so"])
-          dynamic_links
+      @ dynamic_link_flags
     in
     { C.Pkg_config.cflags; libs }
   in
@@ -69,7 +68,7 @@ let torch_flags () =
          | Some "1" ->
            Some
              { C.Pkg_config.cflags = []
-             ; libs = List.map ~f:(fun lib -> [%string "-l%{lib}"]) dynamic_links
+             ; libs = dynamic_link_flags
              }
          | _ -> None)
     (* try conda environment *)


### PR DESCRIPTION
I test the examples on `v0.17~preview.129.00+111` at commit b1ee8db5c9aa150d76a9b24dbb55f1c79cfd3655 and then cherry-pick my change to the latest commit 3aa49efabe26fa622bfe54a571cf140704485630. I cannot test it on this commit due to the linking problem that hasn't been solved #9.

The examples are at least buildable and some unaffected ones can run to finish.

I marked examples that may have a runtime problem with (*). They're caused by `Torch.argmax`.

I believe all the models in the `README` are obsolete. I only tested `VGG-16` and `ResNet-18` used in some examples.

`bin/dune` has to be commented out due to missing of the up-to-date `npy`.

The change for two longer pieces of code in the related files is just for ocamlformat result (with `profile=janestreet`).