### PR TITLE
Add function to unbox `Scalar.int` or `Scalar.float`.

### DIFF
--- a/src/stubs/torch_bindings.ml
+++ b/src/stubs/torch_bindings.ml
@@ -115,6 +115,8 @@ module C (F : Cstubs.FOREIGN) = struct
     type t = unit ptr
 
     let t : t typ = ptr void
+    let to_int64 = foreign "ats_to_int" (t @-> returning int64_t)
+    let to_float = foreign "ats_to_float" (t @-> returning float)
     let int = foreign "ats_int" (int64_t @-> returning t)
     let float = foreign "ats_float" (float @-> returning t)
     let free = foreign "ats_free" (t @-> returning void)

--- a/src/tests/scalar_tests.ml
+++ b/src/tests/scalar_tests.ml
@@ -1,0 +1,16 @@
+open Base
+open Torch
+
+let%expect_test _ =
+  let x = 42 |> Tensor.Scalar.int |> Tensor.Scalar.to_int in
+  Stdio.print !"%d" x;
+  [%expect {|
+      |}]
+;;
+
+let%expect_test _ =
+  let x = 42.0 |> Tensor.Scalar.float |> Tensor.Scalar.to_float in
+  Stdio.print !"%f" x;
+  [%expect {|
+      |}]
+;;

--- a/src/torch/scalar.ml
+++ b/src/torch/scalar.ml
@@ -2,3 +2,4 @@ include Torch_core.Wrapper.Scalar
 
 let f = float
 let i = int
+let to_int s = s |> to_int64 |> Int64.to_int

--- a/src/torch/scalar.mli
+++ b/src/torch/scalar.mli
@@ -2,3 +2,4 @@ include module type of Torch_core.Wrapper.Scalar
 
 val f : float -> float t
 val i : int -> int t
+val to_int : int t -> int

--- a/src/wrapper/torch_api.h
+++ b/src/wrapper/torch_api.h
@@ -104,6 +104,8 @@ void ato_free(optimizer);
 
 scalar ats_int(int64_t);
 scalar ats_float(double);
+int64_t ats_to_int(scalar);
+double ats_to_float(scalar);
 void ats_free(scalar);
 
 int atc_cuda_device_count();

--- a/src/wrapper/wrapper.mli
+++ b/src/wrapper/wrapper.mli
@@ -9,6 +9,8 @@ module Scalar : sig
 
   val int : int -> int t
   val float : float -> float t
+  val to_int64 : int t -> int64
+  val to_float : float t -> float
 end
 
 module Tensor : sig


### PR DESCRIPTION
The C function for unboxing scalar is already in `torch_api.cpp` so I just added them two `ats_to_int` `ats_to_float` to `torch_api.h`.

At this moment, I am not very clear about some design rationale of the library, but I am guessing `src/stubs/torch_bindings.ml` and `src/wrapper/wrapper.ml` are aware of the C functions and `src/torch/scalar.ml` is more ocaml friendly.

And the same as #10, I only test the building at commit https://github.com/janestreet/torch/commit/b1ee8db5c9aa150d76a9b24dbb55f1c79cfd3655. I also don't figure out how to run the test but I wrote an executable to try these new functions.