### PR TITLE
Fixing building for macos

### DIFF
--- a/examples/translation/dune
+++ b/examples/translation/dune
@@ -4,3 +4,8 @@
  (libraries stdio torch unix)
  (preprocess
   (pps ppx_jane)))
+
+(env
+ (dev
+  (flags
+   (:standard -w -32))))

--- a/src/gen_bindings/dune
+++ b/src/gen_bindings/dune
@@ -4,3 +4,8 @@
  (libraries base core.command core_unix.command_unix stdio yaml)
  (preprocess
   (pps ppx_let ppx_string)))
+
+(env
+ (dev
+  (flags
+   (:standard -w -69))))

--- a/src/torch/optimizer.ml
+++ b/src/torch/optimizer.ml
@@ -145,7 +145,7 @@ module Linear_interpolation = struct
       let index =
         Array.binary_search t.xs `First_greater_than_or_equal_to x ~compare:Float.compare
       in
-      let index = Option.value_local_exn index in
+      let index = Option.value_exn index in
       let prev_x, prev_y = t.xs.(index - 1), t.ys.(index - 1) in
       let next_x, next_y = t.xs.(index), t.ys.(index) in
       ((prev_y *. (next_x -. x)) +. (next_y *. (x -. prev_x))) /. (next_x -. prev_x))

--- a/src/vision/dune
+++ b/src/vision/dune
@@ -9,3 +9,8 @@
  (libraries base stdio torch_core torch)
  (preprocess
   (pps ppx_jane)))
+
+(env
+ (dev
+  (flags
+   (:standard -w -69))))

--- a/src/wrapper/dune
+++ b/src/wrapper/dune
@@ -9,7 +9,7 @@
  (foreign_stubs
   (language c)
   (names torch_stubs torch_stubs_generated)
-  (flags -Wno-error=incompatible-function-pointer-types))
+  (extra_deps torch_api_generated.h torch_api_generated.cpp))
  (name torch_core)
  (public_name torch.core)
  (c_library_flags :standard -lstdc++)
@@ -19,14 +19,6 @@
  (libraries ctypes.foreign ctypes torch_bindings)
  (preprocess
   (pps ppx_jane)))
-
-(rule
- (target torch_api)
- (deps torch_api_generated.h torch_api_generated.cpp)
- (action
-  (progn
-   (copy torch_api_generated.h %{target})
-   (copy torch_api_generated.cpp %{target}))))
 
 (rule
  (targets cxx_flags.sexp flags.sexp)

--- a/src/wrapper/dune
+++ b/src/wrapper/dune
@@ -9,6 +9,7 @@
  (foreign_stubs
   (language c)
   (names torch_stubs torch_stubs_generated)
+  (flags -Wno-error=incompatible-function-pointer-types)
   (extra_deps torch_api_generated.h torch_api_generated.cpp))
  (name torch_core)
  (public_name torch.core)

--- a/src/wrapper/dune
+++ b/src/wrapper/dune
@@ -8,7 +8,8 @@
    (:include cxx_flags.sexp)))
  (foreign_stubs
   (language c)
-  (names torch_stubs torch_stubs_generated))
+  (names torch_stubs torch_stubs_generated)
+  (flags -Wno-error=incompatible-function-pointer-types))
  (name torch_core)
  (public_name torch.core)
  (c_library_flags :standard -lstdc++)
@@ -18,6 +19,14 @@
  (libraries ctypes.foreign ctypes torch_bindings)
  (preprocess
   (pps ppx_jane)))
+
+(rule
+ (target torch_api)
+ (deps torch_api_generated.h torch_api_generated.cpp)
+ (action
+  (progn
+   (copy torch_api_generated.h %{target})
+   (copy torch_api_generated.cpp %{target}))))
 
 (rule
  (targets cxx_flags.sexp flags.sexp)


### PR DESCRIPTION
For #14.

The central change is on `src/wrapper/dune` to add dependencies to `torch_api_generated.h` and `torch_api_generated.cpp`.

The rest is to make it compilable. I guess `Option.value_local_exn` is in your private or future public version in `Base`.